### PR TITLE
EXERCISE got rid of duplicates

### DIFF
--- a/model/src/test/java/jetbrains/jetpad/model/composite/CompositesBetweenTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/composite/CompositesBetweenTest.java
@@ -16,66 +16,78 @@
 package jetbrains.jetpad.model.composite;
 
 import jetbrains.jetpad.test.BaseTestCase;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c11;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c12;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c2;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c21;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c31;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c311;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c312;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c313;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c3131;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c3132;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c3133;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c32;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c331;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c332;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c3331;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c3332;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c3333;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c3334;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c3335;
 import static org.junit.Assert.assertEquals;
 
 public class CompositesBetweenTest extends BaseTestCase {
-  private SimpleCompositesTree tree;
-
-  @Before
-  public void init() {
-    tree = new SimpleCompositesTree();
-  }
 
   @Test
   public void same() {
     SimpleComposite root = new SimpleComposite("root");
     assertBetween(root, root, Collections.<SimpleComposite>emptyList());
-    assertBetween(tree.g, tree.g, Collections.<SimpleComposite>emptyList());
+    assertBetween(c21, c21, Collections.<SimpleComposite>emptyList());
   }
 
   @Test(expected=IllegalArgumentException.class)
   public void nonExisting() {
-    Composites.allBetween(tree.e, new SimpleComposite("alien"));
+    Composites.allBetween(c11, new SimpleComposite("alien"));
   }
 
   @Test(expected=IllegalArgumentException.class)
   public void reversed() {
-    Composites.allBetween(tree.f, tree.e);
+    Composites.allBetween(c12, c11);
   }
 
   @Test
   public void neighbors() {
-    assertBetween(tree.e, tree.f, Collections.<SimpleComposite>emptyList());
-    assertBetween(tree.u, tree.y, asList(tree.v, tree.w, tree.x));
-    assertBetween(tree.v, tree.y, asList(tree.w, tree.x));
-    assertBetween(tree.u, tree.x, asList(tree.v, tree.w));
-    assertBetween(tree.v, tree.x, asList(tree.w));
+    assertBetween(c11, c12, Collections.<SimpleComposite>emptyList());
+    assertBetween(c3331, c3335, asList(c3332, c3333, c3334));
+    assertBetween(c3332, c3335, asList(c3333, c3334));
+    assertBetween(c3331, c3334, asList(c3332, c3333));
+    assertBetween(c3332, c3334, asList(c3333));
   }
 
   @Test
   public void down() {
-    assertBetween(tree.k, tree.t, asList(tree.l, tree.r, tree.s));
-    assertBetween(tree.k, tree.s, asList(tree.l, tree.r));
-    assertBetween(tree.l, tree.t, asList(tree.r, tree.s));
-    assertBetween(tree.l, tree.s, asList(tree.r));
+    assertBetween(c311, c3133, asList(c312, c3131, c3132));
+    assertBetween(c311, c3132, asList(c312, c3131));
+    assertBetween(c312, c3133, asList(c3131, c3132));
+    assertBetween(c312, c3132, asList(c3131));
   }
 
   @Test
   public void up() {
-    assertBetween(tree.e, tree.g, asList(tree.f));
-    assertBetween(tree.f, tree.g, Collections.<SimpleComposite>emptyList());
-    assertBetween(tree.f, tree.r, asList(tree.g, tree.c, tree.k, tree.l));
-    assertBetween(tree.f, tree.i, asList(tree.g, tree.c, tree.k, tree.l, tree.r, tree.s, tree.t, tree.m, tree.h));
-    assertBetween(tree.s, tree.p, asList(tree.t, tree.i, tree.o));
-    assertBetween(tree.s, tree.y, asList(tree.t, tree.i, tree.o, tree.p, tree.u, tree.v, tree.w, tree.x));
-    assertBetween(tree.s, tree.w, asList(tree.t, tree.i, tree.o, tree.p, tree.u, tree.v));
+    assertBetween(c11, c21, asList(c12));
+    assertBetween(c12, c21, Collections.<SimpleComposite>emptyList());
+    assertBetween(c12, c3131, asList(c21, c2, c311, c312));
+    assertBetween(c12, c32, asList(c21, c2, c311, c312, c3131, c3132, c3133, c313, c31));
+    assertBetween(c3132, c332, asList(c3133, c32, c331));
+    assertBetween(c3132, c3335, asList(c3133, c32, c331, c332, c3331, c3332, c3333, c3334));
+    assertBetween(c3132, c3333, asList(c3133, c32, c331, c332, c3331, c3332));
   }
 
   private void assertBetween(SimpleComposite left, SimpleComposite right, List<SimpleComposite> expected) {

--- a/model/src/test/java/jetbrains/jetpad/model/composite/CompositesCommonAncestorTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/composite/CompositesCommonAncestorTest.java
@@ -16,52 +16,56 @@
 package jetbrains.jetpad.model.composite;
 
 import jetbrains.jetpad.test.BaseTestCase;
-import org.junit.Before;
 import org.junit.Test;
 
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c0;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c11;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c2;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c21;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c3;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c31;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c313;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c3131;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c3133;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c32;
+import static jetbrains.jetpad.model.composite.SimpleCompositesTree.c3335;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 public class CompositesCommonAncestorTest extends BaseTestCase {
-  private SimpleCompositesTree tree;
-
-  @Before
-  public void init() {
-    tree = new SimpleCompositesTree();
-  }
 
   @Test
   public void differentTrees() {
-    assertNull(Composites.commonAncestor(tree.c, new SimpleComposite("alien")));
+    assertNull(Composites.commonAncestor(c2, new SimpleComposite("alien")));
   }
 
   @Test
   public void same() {
-    assertCommonAncestor(tree.a, tree.a, tree.a);
-    assertCommonAncestor(tree.d, tree.d, tree.d);
-    assertCommonAncestor(tree.y, tree.y, tree.y);
+    assertCommonAncestor(c0, c0, c0);
+    assertCommonAncestor(c3, c3, c3);
+    assertCommonAncestor(c3335, c3335, c3335);
   }
 
   @Test
   public void ancestor() {
-    assertCommonAncestor(tree.a, tree.h, tree.a);
-    assertCommonAncestor(tree.c, tree.g, tree.c);
-    assertCommonAncestor(tree.d, tree.m, tree.d);
-    assertCommonAncestor(tree.d, tree.r, tree.d);
+    assertCommonAncestor(c0, c31, c0);
+    assertCommonAncestor(c2, c21, c2);
+    assertCommonAncestor(c3, c313, c3);
+    assertCommonAncestor(c3, c3131, c3);
   }
 
   @Test
   public void sameLevel() {
-    assertCommonAncestor(tree.c, tree.d, tree.a);
-    assertCommonAncestor(tree.i, tree.h, tree.d);
-    assertCommonAncestor(tree.r, tree.t, tree.m);
+    assertCommonAncestor(c2, c3, c0);
+    assertCommonAncestor(c32, c31, c3);
+    assertCommonAncestor(c3131, c3133, c313);
   }
 
   @Test
   public void differentLevels() {
-    assertCommonAncestor(tree.e, tree.c, tree.a);
-    assertCommonAncestor(tree.m, tree.i, tree.d);
-    assertCommonAncestor(tree.t, tree.i, tree.d);
+    assertCommonAncestor(c11, c2, c0);
+    assertCommonAncestor(c313, c32, c3);
+    assertCommonAncestor(c3133, c32, c3);
   }
 
   private void assertCommonAncestor(SimpleComposite first, SimpleComposite second, SimpleComposite expected) {

--- a/model/src/test/java/jetbrains/jetpad/model/composite/SimpleCompositesTree.java
+++ b/model/src/test/java/jetbrains/jetpad/model/composite/SimpleCompositesTree.java
@@ -15,33 +15,38 @@
  */
 package jetbrains.jetpad.model.composite;
 
-public class SimpleCompositesTree {
-  public SimpleComposite a, c, d, e, f, g, h, i, k, l, m, o, p, r, s, t, u, v, w, x, y;
+public final class SimpleCompositesTree {
 
-  public SimpleCompositesTree() {
-    a = new SimpleComposite("a",
-      new SimpleComposite("b",
-        e = new SimpleComposite("e"),
-        f = new SimpleComposite("f")),
-      c = new SimpleComposite("c",
-        g = new SimpleComposite("g")),
-      d = new SimpleComposite("d",
-        h = new SimpleComposite("h",
-          k = new SimpleComposite("k"),
-          l = new SimpleComposite("l"),
-          m = new SimpleComposite("m",
-            r = new SimpleComposite("r"),
-            s = new SimpleComposite("s"),
-            t = new SimpleComposite("t"))),
-        i = new SimpleComposite("i"),
-        new SimpleComposite("j",
-          o = new SimpleComposite("o"),
-          p = new SimpleComposite("p"),
-          new SimpleComposite("q",
-            u = new SimpleComposite("u"),
-            v = new SimpleComposite("v"),
-            w = new SimpleComposite("w"),
-            x = new SimpleComposite("x"),
-            y = new SimpleComposite("y")))));
+  static final SimpleComposite c0, c1, c2, c3, c11, c12, c21, c31, c32, c33,
+      c311, c312, c313, c331, c332, c3131, c3132, c3133, c333, c3331, c3332, c3333, c3334, c3335;
+
+  static {
+    c0 = new SimpleComposite("c0",
+        c1 = new SimpleComposite("c1",
+            c11 = new SimpleComposite("c11"),
+            c12 = new SimpleComposite("c12")),
+        c2 = new SimpleComposite("c2",
+            c21 = new SimpleComposite("c21")),
+        c3 = new SimpleComposite("c3",
+            c31 = new SimpleComposite("c31",
+                c311 = new SimpleComposite("c311"),
+                c312 = new SimpleComposite("c312"),
+                c313 = new SimpleComposite("c313",
+                    c3131 = new SimpleComposite("c3131"),
+                    c3132 = new SimpleComposite("c3132"),
+                    c3133 = new SimpleComposite("c3133"))),
+            c32 = new SimpleComposite("c32"),
+            c33 = new SimpleComposite("c33",
+                c331 = new SimpleComposite("c331"),
+                c332 = new SimpleComposite("c332"),
+                c333 = new SimpleComposite("c333",
+                    c3331 = new SimpleComposite("c3331"),
+                    c3332 = new SimpleComposite("c3332"),
+                    c3333 = new SimpleComposite("c3333"),
+                    c3334 = new SimpleComposite("c3334"),
+                    c3335 = new SimpleComposite("c3335")))));
+  }
+
+  private SimpleCompositesTree() {
   }
 }


### PR DESCRIPTION
That's exactly the case that shows how straightforward **Locate duplications** analysis is. It's a typical false positive example. The only way of reduce duplication score is to get rid of *tree* usage as I did. Now score is 32.

In addition to main part of the exercise I got rid if **Encapsulate field** warning in **SimpleCompositesTree** + gave some reasonable names to fields there. a,b,c,d, .. - are definitely not the case because we are human