### PR TITLE
(exercise) remove duplication (CompositesBetweenTest)

### DIFF
--- a/model/src/main/java/jetbrains/jetpad/model/composite/Composites.java
+++ b/model/src/main/java/jetbrains/jetpad/model/composite/Composites.java
@@ -528,7 +528,7 @@ public final class Composites {
   }
 
   /**
-   * Returns a lists that includes all nodes that have some parent strictly between
+   * Returns a list that includes all nodes that have some parent strictly between
    * some parents of {@code from} and {@code from}.
    */
   public static <CompositeT extends NavComposite<CompositeT>>

--- a/model/src/test/java/jetbrains/jetpad/model/composite/CompositesBetweenTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/composite/CompositesBetweenTest.java
@@ -19,66 +19,130 @@ import jetbrains.jetpad.test.BaseTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
-import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
 public class CompositesBetweenTest extends BaseTestCase {
-  private SimpleCompositesTree tree;
+
+  private SimpleComposite c;
+  private SimpleComposite e;
+  private SimpleComposite f;
+  private SimpleComposite g;
+  private SimpleComposite h;
+  private SimpleComposite i;
+  private SimpleComposite k;
+  private SimpleComposite l;
+  private SimpleComposite m;
+  private SimpleComposite o;
+  private SimpleComposite p;
+  private SimpleComposite r;
+  private SimpleComposite s;
+  private SimpleComposite t;
+  private SimpleComposite u;
+  private SimpleComposite v;
+  private SimpleComposite w;
+  private SimpleComposite x;
+  private SimpleComposite y;
 
   @Before
   public void init() {
-    tree = new SimpleCompositesTree();
+    SimpleCompositesTree tree = new SimpleCompositesTree();
+    c = tree.getC();
+    e = tree.getE();
+    f = tree.getF();
+    g = tree.getG();
+    h = tree.getH();
+    i = tree.getI();
+    k = tree.getK();
+    l = tree.getL();
+    m = tree.getM();
+    o = tree.getO();
+    p = tree.getP();
+    r = tree.getR();
+    s = tree.getS();
+    t = tree.getT();
+    u = tree.getU();
+    v = tree.getV();
+    w = tree.getW();
+    x = tree.getX();
+    y = tree.getY();
   }
 
   @Test
-  public void same() {
+  public void sameRoot() {
     SimpleComposite root = new SimpleComposite("root");
-    assertBetween(root, root, Collections.<SimpleComposite>emptyList());
-    assertBetween(tree.g, tree.g, Collections.<SimpleComposite>emptyList());
-  }
-
-  @Test(expected=IllegalArgumentException.class)
-  public void nonExisting() {
-    Composites.allBetween(tree.e, new SimpleComposite("alien"));
-  }
-
-  @Test(expected=IllegalArgumentException.class)
-  public void reversed() {
-    Composites.allBetween(tree.f, tree.e);
+    assertBetween(root, root, list());
   }
 
   @Test
-  public void neighbors() {
-    assertBetween(tree.e, tree.f, Collections.<SimpleComposite>emptyList());
-    assertBetween(tree.u, tree.y, asList(tree.v, tree.w, tree.x));
-    assertBetween(tree.v, tree.y, asList(tree.w, tree.x));
-    assertBetween(tree.u, tree.x, asList(tree.v, tree.w));
-    assertBetween(tree.v, tree.x, asList(tree.w));
+  public void sameLeaf() {
+    assertBetween(g, g, list());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void nonExisting() {
+    Composites.allBetween(e, new SimpleComposite("alien"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void reversed() {
+    Composites.allBetween(f, e);
+  }
+
+  @Test
+  public void twoSiblings() {
+    assertConsecutiveNodes(e, f);
+  }
+
+  @Test
+  public void fiveSiblings() {
+    assertConsecutiveNodes(u, v, w, x, y);
   }
 
   @Test
   public void down() {
-    assertBetween(tree.k, tree.t, asList(tree.l, tree.r, tree.s));
-    assertBetween(tree.k, tree.s, asList(tree.l, tree.r));
-    assertBetween(tree.l, tree.t, asList(tree.r, tree.s));
-    assertBetween(tree.l, tree.s, asList(tree.r));
+    assertConsecutiveNodes(k, l, r, s, t);
   }
 
   @Test
-  public void up() {
-    assertBetween(tree.e, tree.g, asList(tree.f));
-    assertBetween(tree.f, tree.g, Collections.<SimpleComposite>emptyList());
-    assertBetween(tree.f, tree.r, asList(tree.g, tree.c, tree.k, tree.l));
-    assertBetween(tree.f, tree.i, asList(tree.g, tree.c, tree.k, tree.l, tree.r, tree.s, tree.t, tree.m, tree.h));
-    assertBetween(tree.s, tree.p, asList(tree.t, tree.i, tree.o));
-    assertBetween(tree.s, tree.y, asList(tree.t, tree.i, tree.o, tree.p, tree.u, tree.v, tree.w, tree.x));
-    assertBetween(tree.s, tree.w, asList(tree.t, tree.i, tree.o, tree.p, tree.u, tree.v));
+  public void cousins() {
+    assertConsecutiveNodes(e, f, g);
+  }
+
+  @Test
+  public void upSidewaysAndDown() {
+    assertBetween(f, c, list());
+    assertBetween(f, g, list());
+    assertBetween(f, k, list(g, c));
+    assertBetween(f, r, list(g, c, k, l));
+    assertBetween(f, i, list(g, c, k, l, r, s, t, m, h));
+  }
+
+  @Test
+  public void upAndDown() {
+    assertConsecutiveNodes(s, t, i, o, p, u, v, w, x, y);
+  }
+
+  private void assertConsecutiveNodes(SimpleComposite... nodes) {
+    List<SimpleComposite> nodeList = list(nodes);
+    for (int i = 0; i < nodeList.size(); i++) {
+      SimpleComposite left = nodeList.get(i);
+      for (int j = i + 1; j < nodeList.size(); j++) {
+        SimpleComposite right = nodeList.get(j);
+        List<SimpleComposite> expectedSubList = nodeList.subList(i + 1, j);
+        assertBetween(left, right, expectedSubList);
+      }
+    }
   }
 
   private void assertBetween(SimpleComposite left, SimpleComposite right, List<SimpleComposite> expected) {
-    assertEquals(expected, Composites.allBetween(left, right));
+    assertEquals("left: " + left + ", right: " + right, expected, Composites.allBetween(left, right));
   }
+
+  private List<SimpleComposite> list(SimpleComposite... simpleComposites) {
+    return Arrays.asList(simpleComposites);
+  }
+
 }

--- a/model/src/test/java/jetbrains/jetpad/model/composite/CompositesCommonAncestorTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/composite/CompositesCommonAncestorTest.java
@@ -25,43 +25,66 @@ import static org.junit.Assert.assertSame;
 public class CompositesCommonAncestorTest extends BaseTestCase {
   private SimpleCompositesTree tree;
 
+  private SimpleComposite a;
+  private SimpleComposite c;
+  private SimpleComposite d;
+  private SimpleComposite e;
+  private SimpleComposite g;
+  private SimpleComposite h;
+  private SimpleComposite i;
+  private SimpleComposite m;
+  private SimpleComposite r;
+  private SimpleComposite t;
+  private SimpleComposite y;
+
   @Before
   public void init() {
     tree = new SimpleCompositesTree();
+    a = tree.getA();
+    c = tree.getC();
+    d = tree.getD();
+    e = tree.getE();
+    g = tree.getG();
+    h = tree.getH();
+    i = tree.getI();
+    m = tree.getM();
+    r = tree.getR();
+    t = tree.getT();
+    y = tree.getY();
   }
 
   @Test
   public void differentTrees() {
-    assertNull(Composites.commonAncestor(tree.c, new SimpleComposite("alien")));
+    assertNull(Composites.commonAncestor(c, new SimpleComposite("alien")));
   }
 
   @Test
   public void same() {
-    assertCommonAncestor(tree.a, tree.a, tree.a);
-    assertCommonAncestor(tree.d, tree.d, tree.d);
-    assertCommonAncestor(tree.y, tree.y, tree.y);
+    assertCommonAncestor(a, a, a);
+    assertCommonAncestor(d, d, d);
+    assertCommonAncestor(y, y, y);
   }
 
   @Test
   public void ancestor() {
-    assertCommonAncestor(tree.a, tree.h, tree.a);
-    assertCommonAncestor(tree.c, tree.g, tree.c);
-    assertCommonAncestor(tree.d, tree.m, tree.d);
-    assertCommonAncestor(tree.d, tree.r, tree.d);
+    assertCommonAncestor(a, h, a);
+    assertCommonAncestor(c, g, c);
+    assertCommonAncestor(d, m, d);
+    assertCommonAncestor(d, r, d);
   }
 
   @Test
   public void sameLevel() {
-    assertCommonAncestor(tree.c, tree.d, tree.a);
-    assertCommonAncestor(tree.i, tree.h, tree.d);
-    assertCommonAncestor(tree.r, tree.t, tree.m);
+    assertCommonAncestor(c, d, a);
+    assertCommonAncestor(i, h, d);
+    assertCommonAncestor(r, t, m);
   }
 
   @Test
   public void differentLevels() {
-    assertCommonAncestor(tree.e, tree.c, tree.a);
-    assertCommonAncestor(tree.m, tree.i, tree.d);
-    assertCommonAncestor(tree.t, tree.i, tree.d);
+    assertCommonAncestor(e, c, a);
+    assertCommonAncestor(m, i, d);
+    assertCommonAncestor(t, i, d);
   }
 
   private void assertCommonAncestor(SimpleComposite first, SimpleComposite second, SimpleComposite expected) {

--- a/model/src/test/java/jetbrains/jetpad/model/composite/SimpleCompositesTree.java
+++ b/model/src/test/java/jetbrains/jetpad/model/composite/SimpleCompositesTree.java
@@ -15,33 +15,146 @@
  */
 package jetbrains.jetpad.model.composite;
 
-public class SimpleCompositesTree {
-  public SimpleComposite a, c, d, e, f, g, h, i, k, l, m, o, p, r, s, t, u, v, w, x, y;
+class SimpleCompositesTree {
 
-  public SimpleCompositesTree() {
+  private SimpleComposite a;
+  private SimpleComposite c;
+  private SimpleComposite d;
+  private SimpleComposite e;
+  private SimpleComposite f;
+  private SimpleComposite g;
+  private SimpleComposite h;
+  private SimpleComposite i;
+  private SimpleComposite k;
+  private SimpleComposite l;
+  private SimpleComposite m;
+  private SimpleComposite o;
+  private SimpleComposite p;
+  private SimpleComposite r;
+  private SimpleComposite s;
+  private SimpleComposite t;
+  private SimpleComposite u;
+  private SimpleComposite v;
+  private SimpleComposite w;
+  private SimpleComposite x;
+  private SimpleComposite y;
+
+  SimpleCompositesTree() {
     a = new SimpleComposite("a",
-      new SimpleComposite("b",
-        e = new SimpleComposite("e"),
-        f = new SimpleComposite("f")),
-      c = new SimpleComposite("c",
-        g = new SimpleComposite("g")),
-      d = new SimpleComposite("d",
-        h = new SimpleComposite("h",
-          k = new SimpleComposite("k"),
-          l = new SimpleComposite("l"),
-          m = new SimpleComposite("m",
-            r = new SimpleComposite("r"),
-            s = new SimpleComposite("s"),
-            t = new SimpleComposite("t"))),
-        i = new SimpleComposite("i"),
-        new SimpleComposite("j",
-          o = new SimpleComposite("o"),
-          p = new SimpleComposite("p"),
-          new SimpleComposite("q",
-            u = new SimpleComposite("u"),
-            v = new SimpleComposite("v"),
-            w = new SimpleComposite("w"),
-            x = new SimpleComposite("x"),
-            y = new SimpleComposite("y")))));
+        new SimpleComposite("b",
+            e = new SimpleComposite("e"),
+            f = new SimpleComposite("f")
+        ),
+        c = new SimpleComposite("c",
+            g = new SimpleComposite("g")
+        ),
+        d = new SimpleComposite("d",
+            h = new SimpleComposite("h",
+                k = new SimpleComposite("k"),
+                l = new SimpleComposite("l"),
+                m = new SimpleComposite("m",
+                    r = new SimpleComposite("r"),
+                    s = new SimpleComposite("s"),
+                    t = new SimpleComposite("t")
+                )
+            ),
+            i = new SimpleComposite("i"),
+            new SimpleComposite("j",
+                o = new SimpleComposite("o"),
+                p = new SimpleComposite("p"),
+                new SimpleComposite("q",
+                    u = new SimpleComposite("u"),
+                    v = new SimpleComposite("v"),
+                    w = new SimpleComposite("w"),
+                    x = new SimpleComposite("x"),
+                    y = new SimpleComposite("y")
+                )
+            )
+        )
+    );
+  }
+
+  SimpleComposite getA() {
+    return a;
+  }
+
+  SimpleComposite getC() {
+    return c;
+  }
+
+  SimpleComposite getD() {
+    return d;
+  }
+
+  SimpleComposite getE() {
+    return e;
+  }
+
+  SimpleComposite getF() {
+    return f;
+  }
+
+  SimpleComposite getG() {
+    return g;
+  }
+
+  SimpleComposite getH() {
+    return h;
+  }
+
+  SimpleComposite getI() {
+    return i;
+  }
+
+  SimpleComposite getK() {
+    return k;
+  }
+
+  SimpleComposite getL() {
+    return l;
+  }
+
+  SimpleComposite getM() {
+    return m;
+  }
+
+  SimpleComposite getO() {
+    return o;
+  }
+
+  SimpleComposite getP() {
+    return p;
+  }
+
+  SimpleComposite getR() {
+    return r;
+  }
+
+  SimpleComposite getS() {
+    return s;
+  }
+
+  SimpleComposite getT() {
+    return t;
+  }
+
+  SimpleComposite getU() {
+    return u;
+  }
+
+  SimpleComposite getV() {
+    return v;
+  }
+
+  SimpleComposite getW() {
+    return w;
+  }
+
+  SimpleComposite getX() {
+    return x;
+  }
+
+  SimpleComposite getY() {
+    return y;
   }
 }


### PR DESCRIPTION
Previous PR: https://github.com/JetBrains/mapper/pull/187

better test names, assertConsecutiveNodes, field encapsulation

Includes Leonid's ideas: https://github.com/JetBrains/mapper/pull/188
and as a result the tests have more checks than before

Added new tests:
```
    assertBetween(f, c, list());
    assertBetween(f, g, list());

```