### PR TITLE
Exercise: Generalize Synchronizers#forPropsOneWay

### DIFF
--- a/mapper/src/main/java/jetbrains/jetpad/mapper/Synchronizers.java
+++ b/mapper/src/main/java/jetbrains/jetpad/mapper/Synchronizers.java
@@ -118,14 +118,14 @@ public final class Synchronizers {
   }
 
   public static <ValueT>
-  Synchronizer forPropsOneWay(final ReadableProperty<ValueT> source, final WritableProperty<ValueT> target) {
+  Synchronizer forPropsOneWay(final ReadableProperty<? extends ValueT> source, final WritableProperty<? super ValueT> target) {
     return new RegistrationSynchronizer() {
       @Override
       protected Registration doAttach(SynchronizerContext ctx) {
         target.set(source.get());
-        return source.addHandler(new EventHandler<PropertyChangeEvent<ValueT>>() {
+        return source.addHandler(new EventHandler<PropertyChangeEvent<? extends ValueT>>() {
           @Override
-          public void onEvent(PropertyChangeEvent<ValueT> event) {
+          public void onEvent(PropertyChangeEvent<? extends ValueT> event) {
             target.set(event.getNewValue());
           }
         });

--- a/mapper/src/test/java/jetbrains/jetpad/mapper/SynchronizersTest.java
+++ b/mapper/src/test/java/jetbrains/jetpad/mapper/SynchronizersTest.java
@@ -87,4 +87,22 @@ public class SynchronizersTest extends BaseTestCase {
     prop.set(4);
     assertEquals(Arrays.asList(1, 2, 3), handled);
   }
+
+  @Test
+  public void forPropsOneWay() {
+    final Property<Integer> integerProperty = new ValueProperty<>();
+    final Property<Number> numberProperty = new ValueProperty<>();
+
+    Mapper<Void, Void> mapper = new Mapper<Void, Void>(null, null) {
+      @Override
+      protected void registerSynchronizers(SynchronizersConfiguration conf) {
+        super.registerSynchronizers(conf);
+        conf.add(Synchronizers.forPropsOneWay(integerProperty, numberProperty));
+      }
+    };
+    mapper.attachRoot();
+
+    integerProperty.set(1);
+    assertEquals(numberProperty.get(), 1);
+  }
 }


### PR DESCRIPTION
Relates to https://github.com/JetBrains/datalore/pull/25, they should be merged together or not at all.

Not in Transformers, but the exercise was broadened. This allows us to remove generics from the method signature of `StatusMapper#innerTextOf` (and possibly other places as well).

BTW, if this change is accepted, then the method body of `onAttach` is identical to `PropertyBinding#bindOneWay`, we could probably just return `PropertyBinding#bindOneWay` in this method then.