### PR TITLE
TPV-3972 Fix vulnerable dependency - JetBrains/mapper - maven:com.goo…

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -15,7 +15,7 @@
     <hamcrest.version>1.3</hamcrest.version>
     <mockito.version>1.9.5</mockito.version>
 
-    <guava.version>22.0</guava.version>
+    <guava.version>27.0.1-jre</guava.version>
     <gwtquery.version>1.5-beta1</gwtquery.version>
     <gwt.version>2.8.1</gwt.version>
     <gwtplugin.version>2.8.1</gwtplugin.version>


### PR DESCRIPTION
…gle.guava:guava:22.0 < 24.1.1-jre (update guava: 22.0 -> 27.0.1-jre)